### PR TITLE
Simplify, and make .clang-tidy agree with .clang-format

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,25 +5,11 @@ HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
   - key:             google-readability-function-size.StatementThreshold
     value:           '800'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
   - key:             modernize-loop-convert.MaxCopySize
     value:           '16'
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
   - key:             modernize-loop-convert.NamingStyle
     value:           CamelCase
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-nullptr.NullMacros
-    value:           'NULL'
 ...
 


### PR DESCRIPTION
I read https://clang.llvm.org/extra/clang-tidy/checks/list.html for a bit and came up with these changes:

No-ops:
    NULL is a NULL macro in the default config;
    include-style defaults to llvm;
    the default loop-convert confidence is reasonable.

Actual changes:
    Always require braces (the default behaviour in clang-tidy);
    Require 1 space before namespace comments (like in .clang-format);
    Always require namespace comments (like in .clang-format)

I couldn't find any information about `modernize-loop-convert.NamingStyle` or `modernize-loop-convert.MaxCopySize`