### PR TITLE
Silence clang-tidy's complaints about warnings in non-user code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       script:
         - mkdir -p _build && cd _build
         - CXX=clang++-7 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-        - run-clang-tidy-7.py -p . "core|application"
+        - run-clang-tidy-7.py -q -p . "core|application"
 
 install:
   - mkdir -p cmake-3.12


### PR DESCRIPTION
Printing
```
9601 warnings generated.
Suppressed 9620 warnings (9601 in non-user code, 19 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
for every file scanned isn't helpful to anyone.