### PR TITLE
Fix stack not being written in the ram bank

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -29,8 +29,26 @@ const uint16_t kBrkAddress = 0xFFFE; // This is where the break routine is.
 
 namespace n_e_s::core {
 
+Mos6502::Ram::Ram(IMmu *mmu) : mmu_(mmu) {}
+
+uint8_t Mos6502::Ram::read_byte(uint8_t addr) const {
+    return mmu_->read_byte(ram_offset_ + addr);
+}
+
+uint16_t Mos6502::Ram::read_word(uint8_t addr) const {
+    return mmu_->read_word(ram_offset_ + addr);
+}
+
+void Mos6502::Ram::write_byte(uint8_t addr, uint8_t byte) {
+    mmu_->write_byte(ram_offset_ + addr, byte);
+}
+
+void Mos6502::Ram::write_word(uint8_t addr, uint16_t word) {
+    mmu_->write_word(ram_offset_ + addr, word);
+}
+
 Mos6502::Mos6502(Registers *const registers, IMmu *const mmu)
-        : registers_(registers), mmu_(mmu), pipeline_() {}
+        : registers_(registers), mmu_(mmu), ram_(mmu_), pipeline_() {}
 
 // Most instruction timings are from https://robinli.eu/f/6502_cpu.txt
 void Mos6502::execute() {
@@ -46,10 +64,10 @@ void Mos6502::execute() {
             });
             pipeline_.push([=]() {
                 registers_->sp -= 2;
-                mmu_->write_word(registers_->sp, registers_->pc);
+                ram_.write_word(registers_->sp, registers_->pc);
             });
             pipeline_.push([=]() {
-                mmu_->write_byte(--registers_->sp, registers_->p | B_FLAG);
+                ram_.write_byte(--registers_->sp, registers_->p | B_FLAG);
             });
             pipeline_.push([=]() { ++registers_->pc; });
             pipeline_.push(

--- a/core/src/mos6502.h
+++ b/core/src/mos6502.h
@@ -23,6 +23,25 @@ private:
     Registers *const registers_;
     IMmu *const mmu_;
 
+    // Exactly like the mmu except that the address is offset to be inside
+    // the ram bank.
+    class Ram {
+    public:
+        Ram(IMmu *mmu);
+
+        uint8_t read_byte(uint8_t addr) const;
+        uint16_t read_word(uint8_t addr) const;
+
+        void write_byte(uint8_t addr, uint8_t byte);
+        void write_word(uint8_t addr, uint16_t word);
+
+    private:
+        IMmu *const mmu_;
+        const uint16_t ram_offset_{0x0100};
+    };
+
+    Ram ram_;
+
     // Holds the atoms staged to be executed.
     std::queue<std::function<void()>> pipeline_;
 

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -24,6 +24,7 @@ static bool operator==(const Registers &a, const Registers &b) {
 
 namespace {
 
+const uint16_t kStackOffset = 0x0100;
 const uint16_t kBrkAddress = 0xFFFE;
 
 // Tests and opcodes should be written without looking at the cpu
@@ -90,8 +91,10 @@ TEST_F(CpuTest, brk) {
     ON_CALL(mmu, read_word(kBrkAddress)).WillByDefault(Return(0xDEAD));
 
     // First the return address is pushed and then the registers.
-    EXPECT_CALL(mmu, write_word(expected_pc_stack_addr, registers.pc + 2));
-    EXPECT_CALL(mmu, write_byte(expected_p_stack_addr, registers.p | B_FLAG));
+    EXPECT_CALL(mmu, write_word(kStackOffset + expected_pc_stack_addr,
+                                registers.pc + 2));
+    EXPECT_CALL(mmu, write_byte(kStackOffset + expected_p_stack_addr,
+                                registers.p | B_FLAG));
 
     step_execution(7);
 


### PR DESCRIPTION
```
     S Stack pointer
          The NMOS 65xx processors have 256 bytes of stack memory, ranging
          from $0100 to $01FF. The S register is a 8-bit offset to the stack
          page. In other words, whenever anything is being pushed on the
          stack, it will be stored to the address $0100+S.
```