### PR TITLE
Add LDY for immediate mode

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -17,6 +17,7 @@ enum Opcode : uint8_t {
     JMP = 0x4C,
     CLI = 0x58,
     SEI = 0x78,
+    LDY_I = 0xA0,
     CLV = 0xB8,
     CLD = 0xD8,
     NOP = 0xEA,
@@ -105,6 +106,13 @@ void Mos6502::execute() {
             return;
         case SEI:
             pipeline_.push([=]() { set_flag(I_FLAG); });
+            return;
+        case LDY_I:
+            pipeline_.push([=]() {
+                registers_->y = mmu_->read_byte(registers_->pc++);
+                set_zero(registers_->y);
+                set_negative(registers_->y);
+            });
             return;
         case CLV:
             pipeline_.push([=]() { clear_flag(V_FLAG); });

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -38,6 +38,7 @@ enum Opcode : uint8_t {
     JMP = 0x4C,
     CLI = 0x58,
     SEI = 0x78,
+    LDY_I = 0xA0,
     CLV = 0xB8,
     CLD = 0xD8,
     NOP = 0xEA,
@@ -210,6 +211,65 @@ TEST_F(CpuTest, cli) {
 TEST_F(CpuTest, sei) {
     stage_instruction(SEI);
     expected.p |= I_FLAG;
+
+    step_execution(2);
+    EXPECT_EQ(expected, registers);
+}
+
+TEST_F(CpuTest, ldy_i_sets_y) {
+    stage_instruction(LDY_I);
+    expected.y = 42;
+    ++expected.pc;
+
+    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(expected.y));
+
+    step_execution(2);
+    EXPECT_EQ(expected, registers);
+}
+
+TEST_F(CpuTest, ldy_i_sets_n_flag) {
+    stage_instruction(LDY_I);
+    expected.y = 128;
+    expected.p |= N_FLAG;
+    ++expected.pc;
+
+    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(expected.y));
+
+    step_execution(2);
+    EXPECT_EQ(expected, registers);
+}
+
+TEST_F(CpuTest, ldy_i_clears_n_flag) {
+    stage_instruction(LDY_I);
+    registers.p |= N_FLAG;
+    expected.y = 127;
+    ++expected.pc;
+
+    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(expected.y));
+
+    step_execution(2);
+    EXPECT_EQ(expected, registers);
+}
+
+TEST_F(CpuTest, ldy_i_sets_z_flag) {
+    stage_instruction(LDY_I);
+    expected.y = 0;
+    expected.p |= Z_FLAG;
+    ++expected.pc;
+
+    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(expected.y));
+
+    step_execution(2);
+    EXPECT_EQ(expected, registers);
+}
+
+TEST_F(CpuTest, ldy_i_clears_z_flag) {
+    stage_instruction(LDY_I);
+    registers.p |= Z_FLAG;
+    expected.y = 1;
+    ++expected.pc;
+
+    ON_CALL(mmu, read_byte(registers.pc + 1)).WillByDefault(Return(expected.y));
 
     step_execution(2);
     EXPECT_EQ(expected, registers);


### PR DESCRIPTION
Load Y register, immediate addressing.

>   Immediate addressing
>         #  address R/W description
>        --- ------- --- ------------------------------------------
>         1    PC     R  fetch opcode, increment PC
>         2    PC     R  fetch value, increment PC

Many of these instructions will be similar (LDA, LDX, LDY) and with the same addressing modes. We probably need to refactor both the pipeline and the tests later to make them easier to implement.