### PR TITLE
Have lsr unset N flag

### DIFF
--- a/core/src/mos6502.cpp
+++ b/core/src/mos6502.cpp
@@ -95,6 +95,7 @@ void Mos6502::execute() {
                 registers_->a &= ~1;
                 registers_->a >>= 1;
                 set_zero(registers_->a);
+                clear_flag(N_FLAG);
             });
             return;
         case PHA:

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -188,12 +188,12 @@ TEST_F(CpuTest, lsr_a_sets_c_and_z_flags) {
     EXPECT_EQ(expected, registers);
 }
 
-TEST_F(CpuTest, lsr_a_clears_c_and_z_flags) {
+TEST_F(CpuTest, lsr_a_clears_c_z_n_flags) {
     stage_instruction(LSR_A);
     registers.a = 0b00000010;
     registers.p = Z_FLAG | C_FLAG | N_FLAG;
     expected.a = 0b00000001;
-    expected.p = N_FLAG;
+    expected.p = 0;
 
     step_execution(2);
     EXPECT_EQ(expected, registers);


### PR DESCRIPTION
As pointed out by @johnor it seems that lsr should unset the N flag. It also makes more sense than it not doing it.

Resolves #21 