### PR TITLE
Add PrintTo function for better debug printouts for registers

### DIFF
--- a/core/test/src/hexprinter.h
+++ b/core/test/src/hexprinter.h
@@ -1,0 +1,30 @@
+// Copyright 2018 Robin Linden <dev@robinlinden.eu>
+
+#include <climits>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <type_traits>
+
+namespace n_e_s::core::test {
+
+constexpr int HEX_DIGIT_BITS = 4;
+
+template <typename T>
+struct is_char : std::integral_constant<bool,
+                         std::is_same<T, char>::value ||
+                                 std::is_same<T, signed char>::value ||
+                                 std::is_same<T, unsigned char>::value> {};
+
+// Adapted from https://stackoverflow.com/a/35963334
+template <typename T>
+std::string hex_out_s(T val) {
+    std::stringstream sformatter;
+    sformatter << std::hex << std::internal << "0x" << std::setfill('0')
+               << std::setw(sizeof(T) * CHAR_BIT / HEX_DIGIT_BITS)
+               << (is_char<T>::value ? static_cast<int>(val) : val);
+
+    return sformatter.str();
+}
+} // namespace n_e_s::core::test

--- a/core/test/src/test_cpu.cpp
+++ b/core/test/src/test_cpu.cpp
@@ -2,9 +2,12 @@
 
 #include "core/cpu_factory.h"
 
+#include "hexprinter.h"
 #include "mock_mmu.h"
 
 #include <gtest/gtest.h>
+#include <bitset>
+#include <ostream>
 
 using namespace n_e_s::core;
 using namespace n_e_s::core::test;
@@ -18,6 +21,15 @@ namespace n_e_s::core {
 static bool operator==(const Registers &a, const Registers &b) {
     return a.pc == b.pc && a.sp == b.sp && a.a == b.a && a.x == b.x &&
            a.y == b.y && a.p == b.p;
+}
+
+static void PrintTo(const Registers &r, std::ostream *os) {
+    *os << "PC: " << hex_out_s(r.pc);
+    *os << " SP: " << hex_out_s(r.sp);
+    *os << " A: " << hex_out_s(r.a);
+    *os << " X: " << hex_out_s(r.x);
+    *os << " Y: " << hex_out_s(r.y);
+    *os << " P: 0b" << std::bitset<8>(r.p) << std::endl;
 }
 
 } // namespace n_e_s::core


### PR DESCRIPTION
Makes debugging easier. Can probably be improved even more later to print the flags in the status register with name.

Before:
```
  expected
    Which is: 8-byte object <AF-DE 00-00 00-00 80-00>
  registers
    Which is: 8-byte object <AE-DE 00-00 00-00 00-00>
```
After:
``` 
  expected
    Which is: PC: 0xdeaf SP: 0x00 A: 0x00 X: 0x00 Y: 0x00 P: 0b10000000

  registers
    Which is: PC: 0xdeae SP: 0x00 A: 0x00 X: 0x00 Y: 0x00 P: 0b00000000
```